### PR TITLE
GPE-2855 | Add option to configure CSV reader LazyQuote attribute

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @deliveroo/grocery-partner-integrations

--- a/csv_files/lazy_quotes.csv
+++ b/csv_files/lazy_quotes.csv
@@ -1,0 +1,1 @@
+a content with " " chars|false

--- a/csvtag.go
+++ b/csvtag.go
@@ -4,4 +4,5 @@ package csvtag
 type CsvOptions struct {
 	Separator rune
 	Header    []string
+	LazyQuote bool
 }

--- a/load_test.go
+++ b/load_test.go
@@ -157,3 +157,31 @@ func TestNoDist(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestLazyQuotes(t *testing.T) {
+
+	type testQuote struct {
+		Name  string `csv:"name"`
+		ABool bool   `csv:"flag"`
+	}
+
+	type quotes []testQuote
+
+	data := quotes{}
+	err := LoadFromPath("csv_files/lazy_quotes.csv", &data,
+		CsvOptions{Separator: '|',
+			Header: []string{
+				"name",
+				"flag",
+			},
+			LazyQuote: true})
+	if err != nil {
+		t.Errorf("read failed with an error: %s", err.Error())
+	}
+	if len(data) != 1 {
+		t.Error("Expected one row read")
+	}
+	if data[0].Name != "a content with \" \" chars" {
+		t.Error("Received unexpected file content")
+	}
+}


### PR DESCRIPTION
This change allows to use go-csv-tag lib with CSV files having lazy quotes inside. Refactored load.go so that CSV reader creation is separated from usage, to simplify use of parameters.